### PR TITLE
Replace Makefile with atmos.yaml

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -104,8 +104,7 @@ usage: |-
               aws-region: us-east-2
   ```
 
-include:
-  - "docs/github-action.md"
+include: []
 
 # Contributors to this project
 contributors:


### PR DESCRIPTION
## what
- Remove `Makefile`
- Add `atmos.yaml`

## why
- Replace `build-harness` with `atmos` for readme genration

## References
* DEV-3229 Migrate from build-harness to atmos
