### PR TITLE
chore: upgrade actions to Node 24 runtime (SHA-pinned)

### DIFF
--- a/.github/workflows/test-negative.yml
+++ b/.github/workflows/test-negative.yml
@@ -28,7 +28,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set outputs
         id: masked
@@ -46,12 +46,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: ''
           actual: "${{ needs.test.outputs.masked-result }}"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'example'
           actual: "${{ needs.test.outputs.non-masked-result }}"

--- a/.github/workflows/test-positive-secret-2.yml
+++ b/.github/workflows/test-positive-secret-2.yml
@@ -30,7 +30,7 @@ jobs:
     needs: [setup]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set outputs
         id: masked
@@ -56,7 +56,7 @@ jobs:
     needs: [setup, test]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./
         id: masked-result
@@ -65,7 +65,7 @@ jobs:
           op: decode
           in: ${{ needs.test.outputs.masked-result }}
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'test'
           actual: "${{ steps. masked-result.outputs.out }}"

--- a/.github/workflows/test-positive.yml
+++ b/.github/workflows/test-positive.yml
@@ -30,7 +30,7 @@ jobs:
     needs: [setup]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set outputs
         id: masked
@@ -56,7 +56,7 @@ jobs:
     needs: [setup, test]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./
         id: masked-result
@@ -65,7 +65,7 @@ jobs:
           op: decode
           in: ${{ needs.test.outputs.masked-result }}
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'test'
           actual: "${{ steps. masked-result.outputs.out }}"


### PR DESCRIPTION
## what

* Bump GitHub Actions references in the workflows to versions running on the Node 24 runtime,
  SHA-pinned with precise version comments:
  * `actions/checkout@v4` → `@3d3c42e5...` `# v7.0.1`
  * `nick-fields/assert-action@v2` → `@0efd6166...` `# v4.0.1`

## why

* GitHub is deprecating the Node 20 runtime; affected workflows emit a deprecation warning and
  are already being force-migrated to Node 24
* SHA pinning with a verified tag comment makes the upgrade deliberate and supply-chain-safe,
  matching the org's direction in cloudposse/.github#261
* Every pinned SHA was verified against its upstream tag

## references

* https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Supersedes #37
Supersedes #36
